### PR TITLE
Update client.lua

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -87,10 +87,8 @@ elseif Config.Framework == 'qb' then
     end
 end
 
-Unlock = function(vehicle, plate)
--- add your vehicle keys logic/triggers here
-    -- TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(vehicle), 1) -- uncomment if using QB
-    --TriggerServerEvent('shorty_slocks:breakIn', plate)
+Unlock = function(vehicle, plate)  
+    SetVehicleDoorsLocked(vehicle, 1)
 end
 
 RegisterNetEvent('envi-carjack:smash',function(netID)


### PR DESCRIPTION
using fivem natives, you can change the state of vehicledoorlock to 1 for unlocked when commandeering a vehicle. ref: https://docs.fivem.net/natives/?_0xB664292EAECF7FA6 i might have forgot to remove a few spaces. :D 